### PR TITLE
allow to specify a different output path to save preprocessed data

### DIFF
--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -20,6 +20,7 @@ logger = getLogger(__name__)
 
 def extract_trodes_rec_file(data_dir,
                             animal,
+                            out_dir=None,
                             lfp_export_args=_DEFAULT_LFP_EXPORT_ARGS,
                             mda_export_args=_DEFAULT_MDA_EXPORT_ARGS,
                             analog_export_args=_DEFAULT_ANALOG_EXPORT_ARGS,
@@ -56,6 +57,9 @@ def extract_trodes_rec_file(data_dir,
     data_dir : str
     animal : str
         Name of animal
+    out_dir : str, optional (default is None)
+        Path to save preprocessed data (defaults to data_dir if None);
+        subfolders [out_dir]/[animal]/[date]/preprocessing will be created.
     lfp_export_args : tuple, optional
         Parameters for SpikeGadgets `exportLFP` function
     mda_export_args : tuple, optional
@@ -96,7 +100,7 @@ def extract_trodes_rec_file(data_dir,
         (i.e. `<date>.trodesconf`)
 
     """
-    animal_info = td.TrodesAnimalInfo(data_dir, animal)
+    animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
 
     extractor = td.ExtractRawTrodesData(animal_info)
     raw_epochs_unionset = animal_info.get_raw_epochs_unionset()
@@ -181,7 +185,7 @@ def extract_trodes_rec_file(data_dir,
     if make_HDF5:
         # Reload animal_info to get directory structures created during
         # extraction
-        animal_info = td.TrodesAnimalInfo(data_dir, animal)
+        animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
 
         importer = td.TrodesPreprocessingToAnalysis(animal_info)
 

--- a/rec_to_binaries/trodes_data.py
+++ b/rec_to_binaries/trodes_data.py
@@ -213,10 +213,17 @@ class TrodesPosExtractedFileNameParser(TrodesRawFileNameParser):
 
 class TrodesAnimalInfo:
 
-    def __init__(self, base_dir, anim_name, RawFileParser=TrodesRawFileNameParser):
+    def __init__(self, base_dir, anim_name, RawFileParser=TrodesRawFileNameParser,
+                       out_dir=None):
         self.RawFileNameParser = RawFileParser
         self.base_dir = base_dir
         self.anim_name = anim_name
+
+        # optionally choose a different output path to save preprocessed data
+        if out_dir is not None:
+            self.out_dir = out_dir
+        else:
+            self.out_dir = base_dir # default (legacy behavior)
 
         raw_path = self._get_raw_dir(base_dir, anim_name)
 
@@ -504,7 +511,7 @@ class TrodesAnimalInfo:
         return self._get_raw_dir(self.base_dir, self.anim_name)
 
     def get_preprocessing_dir(self):
-        return self._get_preprocessing_dir(self.base_dir, self.anim_name)
+        return self._get_preprocessing_dir(self.out_dir, self.anim_name)
 
     def get_analysis_dir(self):
         return self._get_analysis_dir(self.base_dir, self.anim_name)


### PR DESCRIPTION
This introduces a new keyword argument to the constructor, `out_dir`, which can replace the input `base_dir` for saving the preprocessed data. I find this useful when converting an old dataset that lives in someone else's directory, and when I don't want to write to their directory.

Please feel free to edit - e.g., to rename the attribute or the keyword argument.