### PR TITLE
Add user options - resolve #2

### DIFF
--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -188,7 +188,7 @@ def extract_trodes_rec_file(data_dir,
     if make_HDF5:
         # Reload animal_info to get directory structures created during
         # extraction
-        animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
+        animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir, dates=dates)
 
         importer = td.TrodesPreprocessingToAnalysis(animal_info)
 

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -21,6 +21,7 @@ logger = getLogger(__name__)
 def extract_trodes_rec_file(data_dir,
                             animal,
                             out_dir=None,
+                            dates=None,
                             lfp_export_args=_DEFAULT_LFP_EXPORT_ARGS,
                             mda_export_args=_DEFAULT_MDA_EXPORT_ARGS,
                             analog_export_args=_DEFAULT_ANALOG_EXPORT_ARGS,
@@ -60,6 +61,8 @@ def extract_trodes_rec_file(data_dir,
     out_dir : str, optional (default is None)
         Path to save preprocessed data (defaults to data_dir if None);
         subfolders [out_dir]/[animal]/[date]/preprocessing will be created.
+    dates : list, optional (default is None)
+        Only process select dates (defaults to all available dates if None)
     lfp_export_args : tuple, optional
         Parameters for SpikeGadgets `exportLFP` function
     mda_export_args : tuple, optional
@@ -100,7 +103,7 @@ def extract_trodes_rec_file(data_dir,
         (i.e. `<date>.trodesconf`)
 
     """
-    animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
+    animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir, dates=dates)
 
     extractor = td.ExtractRawTrodesData(animal_info)
     raw_epochs_unionset = animal_info.get_raw_epochs_unionset()

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -20,6 +20,7 @@ logger = getLogger(__name__)
 
 def extract_trodes_rec_file(data_dir,
                             animal,
+                            out_dir=None,
                             lfp_export_args=_DEFAULT_LFP_EXPORT_ARGS,
                             mda_export_args=_DEFAULT_MDA_EXPORT_ARGS,
                             analog_export_args=_DEFAULT_ANALOG_EXPORT_ARGS,
@@ -56,6 +57,9 @@ def extract_trodes_rec_file(data_dir,
     data_dir : str
     animal : str
         Name of animal
+    out_dir : str, optional (default is None)
+        Path to save preprocessed data (defaults to data_dir if None);
+        subfolders [out_dir]/[animal]/[date]/preprocessing will be created.
     lfp_export_args : tuple, optional
         Parameters for SpikeGadgets `exportLFP` function
     mda_export_args : tuple, optional
@@ -96,7 +100,7 @@ def extract_trodes_rec_file(data_dir,
         (i.e. `<date>.trodesconf`)
 
     """
-    animal_info = td.TrodesAnimalInfo(data_dir, animal)
+    animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
 
     extractor = td.ExtractRawTrodesData(animal_info)
     raw_epochs_unionset = animal_info.get_raw_epochs_unionset()
@@ -181,7 +185,7 @@ def extract_trodes_rec_file(data_dir,
     if make_HDF5:
         # Reload animal_info to get directory structures created during
         # extraction
-        animal_info = td.TrodesAnimalInfo(data_dir, animal)
+        animal_info = td.TrodesAnimalInfo(data_dir, animal, out_dir=out_dir)
 
         importer = td.TrodesPreprocessingToAnalysis(animal_info)
 

--- a/rec_to_binaries/trodes_data.py
+++ b/rec_to_binaries/trodes_data.py
@@ -213,10 +213,17 @@ class TrodesPosExtractedFileNameParser(TrodesRawFileNameParser):
 
 class TrodesAnimalInfo:
 
-    def __init__(self, base_dir, anim_name, RawFileParser=TrodesRawFileNameParser):
+    def __init__(self, base_dir, anim_name, RawFileParser=TrodesRawFileNameParser,
+                       out_dir=None):
         self.RawFileNameParser = RawFileParser
         self.base_dir = base_dir
         self.anim_name = anim_name
+
+        # optionally choose a different output path to save preprocessed data
+        if out_dir is not None:
+            self.out_dir = out_dir
+        else:
+            self.out_dir = base_dir # default (legacy behavior)
 
         raw_path = self._get_raw_dir(base_dir, anim_name)
 
@@ -504,7 +511,7 @@ class TrodesAnimalInfo:
         return self._get_raw_dir(self.base_dir, self.anim_name)
 
     def get_preprocessing_dir(self):
-        return self._get_preprocessing_dir(self.base_dir, self.anim_name)
+        return self._get_preprocessing_dir(self.out_dir, self.anim_name)
 
     def get_analysis_dir(self):
         return self._get_analysis_dir(self.base_dir, self.anim_name)

--- a/rec_to_binaries/trodes_data.py
+++ b/rec_to_binaries/trodes_data.py
@@ -214,7 +214,7 @@ class TrodesPosExtractedFileNameParser(TrodesRawFileNameParser):
 class TrodesAnimalInfo:
 
     def __init__(self, base_dir, anim_name, RawFileParser=TrodesRawFileNameParser,
-                       out_dir=None):
+                       out_dir=None, dates=None):
         self.RawFileNameParser = RawFileParser
         self.base_dir = base_dir
         self.anim_name = anim_name
@@ -239,6 +239,10 @@ class TrodesAnimalInfo:
 
         # Loads and caches all raw data files that exist
         for date, day_path in raw_day_paths.items():
+            if dates is not None:
+                # if dates given, only work on these selected dates
+                if date not in dates:
+                    continue
             self.raw_rec_files[date] = {}
             day_rec_filenames = self._get_rec_paths(
                 day_path, self.RawFileNameParser)


### PR DESCRIPTION
Each commit adds an independent option, but they are stacked linearly.

First commit: **allow to specify a different output path to save preprocessed data**

Introduces a new keyword argument to the constructor, `out_dir`, which can replace the input `base_dir` for saving the preprocessed data. I find this useful when converting an old dataset that lives in someone else's directory, and when I don't want to write to their directory.

Please feel free to edit - e.g., to rename the attribute or the keyword argument.