### PR TITLE
Separate hdf5 conversion

### DIFF
--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -224,15 +224,19 @@ def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
     importer = td.TrodesPreprocessingToAnalysis(animal_info)
 
     # Convert binaries into hdf5 files
-    for convert_dio and date in animal_info.preproc_dio_paths['date'].unique():
-        importer.convert_dio_day(date)
+    if convert_dio:
+        for date in animal_info.preproc_dio_paths['date'].unique():
+            importer.convert_dio_day(date)
 
-    for convert_lfp and date in animal_info.preproc_LFP_paths['date'].unique():
-        importer.convert_lfp_day(date)
+    if convert_lfp:
+        for date in animal_info.preproc_LFP_paths['date'].unique():
+            importer.convert_lfp_day(date)
 
-    for convert_pos and date in animal_info.preproc_pos_paths['date'].unique():
-        importer.convert_pos_day(date)
+    if convert_pos:
+        for date in animal_info.preproc_pos_paths['date'].unique():
+            importer.convert_pos_day(date)
 
-    for convert_spike and date in animal_info.preproc_spike_paths['date'].unique():
-        importer.convert_spike_day(
-            date, parallel_instances=parallel_instances)
+    if convert_spike:
+        for date in animal_info.preproc_spike_paths['date'].unique():
+            importer.convert_spike_day(
+                date, parallel_instances=parallel_instances)

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -230,21 +230,21 @@ def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
     # Convert binaries into hdf5 files
     if convert_dio:
         for date in animal_info.preproc_dio_paths['date'].unique():
-            print('converting dio for {} ...'.format(date))
+            logger.info(f'converting dio for {date} ...')
             importer.convert_dio_day(date)
 
     if convert_lfp:
         for date in animal_info.preproc_LFP_paths['date'].unique():
-            print('converting LFP for {} ...'.format(date))
+            logger.info(f'converting LFP for {date} ...')
             importer.convert_lfp_day(date)
 
     if convert_pos:
         for date in animal_info.preproc_pos_paths['date'].unique():
-            print('converting pos for {} ...'.format(date))
+            logger.info(f'converting pos for {date} ...')
             importer.convert_pos_day(date)
 
     if convert_spike:
         for date in animal_info.preproc_spike_paths['date'].unique():
-            print('converting spike for {} ...'.format(date))
+            logger.info(f'converting spike for {date} ...')
             importer.convert_spike_day(
                 date, parallel_instances=parallel_instances)

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -190,10 +190,12 @@ def extract_trodes_rec_file(data_dir,
         logger.info('Converting binaries into HDF5 files...')
         # Reload animal_info to get directory structures created during
         # extraction
-        convert_binaries_to_hdf5(data_dir, animal, out_dir=out_dir, dates=dates)
+        convert_binaries_to_hdf5(data_dir, animal, out_dir=out_dir, dates=dates,
+                                 parallel_instances=parallel_instances)
         
 
 def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
+                             parallel_instances=1,
                              convert_dio=True,
                              convert_lfp=True,
                              convert_pos=True,
@@ -215,6 +217,8 @@ def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
         subfolders [out_dir]/[animal]/[date]/preprocessing will be created.
     dates : list, optional (default is None)
         Only process select dates (defaults to all available dates if None)
+    parallel_instances : int, optional
+        Number of parallel jobs to run.
     convert_spikes : bool, optional
     convert_lfps : bool, optional
     convert_dio : bool, optional

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -194,21 +194,25 @@ def extract_trodes_rec_file(data_dir,
         
 
 def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
+                             convert_dio=True,
+                             convert_lfp=True,
+                             convert_pos=True,
+                             convert_spike=True):
     animal_info = td.TrodesAnimalInfo(
         data_dir, animal, out_dir=out_dir, dates=dates)
 
     importer = td.TrodesPreprocessingToAnalysis(animal_info)
 
     # Convert binaries into hdf5 files
-    for date in animal_info.preproc_dio_paths['date'].unique():
+    for convert_dio and date in animal_info.preproc_dio_paths['date'].unique():
         importer.convert_dio_day(date)
 
-    for date in animal_info.preproc_LFP_paths['date'].unique():
+    for convert_lfp and date in animal_info.preproc_LFP_paths['date'].unique():
         importer.convert_lfp_day(date)
 
-    for date in animal_info.preproc_pos_paths['date'].unique():
+    for convert_pos and date in animal_info.preproc_pos_paths['date'].unique():
         importer.convert_pos_day(date)
 
-    for date in animal_info.preproc_spike_paths['date'].unique():
+    for convert_spike and date in animal_info.preproc_spike_paths['date'].unique():
         importer.convert_spike_day(
             date, parallel_instances=parallel_instances)

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -187,23 +187,28 @@ def extract_trodes_rec_file(data_dir,
             use_folder_date=use_folder_date, stop_error=stop_error)
 
     if make_HDF5:
+        logger.info('Converting binaries into HDF5 files...')
         # Reload animal_info to get directory structures created during
         # extraction
-        animal_info = td.TrodesAnimalInfo(
-            data_dir, animal, out_dir=out_dir, dates=dates)
+        convert_binaries_to_hdf5(data_dir, animal, out_dir=out_dir, dates=dates)
+        
 
-        importer = td.TrodesPreprocessingToAnalysis(animal_info)
+def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
+    animal_info = td.TrodesAnimalInfo(
+        data_dir, animal, out_dir=out_dir, dates=dates)
 
-        # Convert binaries into hdf5 files
-        for date in animal_info.preproc_dio_paths['date'].unique():
-            importer.convert_dio_day(date)
+    importer = td.TrodesPreprocessingToAnalysis(animal_info)
 
-        for date in animal_info.preproc_LFP_paths['date'].unique():
-            importer.convert_lfp_day(date)
+    # Convert binaries into hdf5 files
+    for date in animal_info.preproc_dio_paths['date'].unique():
+        importer.convert_dio_day(date)
 
-        for date in animal_info.preproc_pos_paths['date'].unique():
-            importer.convert_pos_day(date)
+    for date in animal_info.preproc_LFP_paths['date'].unique():
+        importer.convert_lfp_day(date)
 
-        for date in animal_info.preproc_spike_paths['date'].unique():
-            importer.convert_spike_day(
-                date, parallel_instances=parallel_instances)
+    for date in animal_info.preproc_pos_paths['date'].unique():
+        importer.convert_pos_day(date)
+
+    for date in animal_info.preproc_spike_paths['date'].unique():
+        importer.convert_spike_day(
+            date, parallel_instances=parallel_instances)

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -230,17 +230,21 @@ def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
     # Convert binaries into hdf5 files
     if convert_dio:
         for date in animal_info.preproc_dio_paths['date'].unique():
+            print('converting dio for {} ...'.format(date))
             importer.convert_dio_day(date)
 
     if convert_lfp:
         for date in animal_info.preproc_LFP_paths['date'].unique():
+            print('converting LFP for {} ...'.format(date))
             importer.convert_lfp_day(date)
 
     if convert_pos:
         for date in animal_info.preproc_pos_paths['date'].unique():
+            print('converting pos for {} ...'.format(date))
             importer.convert_pos_day(date)
 
     if convert_spike:
         for date in animal_info.preproc_spike_paths['date'].unique():
+            print('converting spike for {} ...'.format(date))
             importer.convert_spike_day(
                 date, parallel_instances=parallel_instances)

--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -200,6 +200,26 @@ def convert_binaries_to_hdf5(data_dir, animal, out_dir=None, dates=None,
                              convert_spike=True):
     animal_info = td.TrodesAnimalInfo(
         data_dir, animal, out_dir=out_dir, dates=dates)
+    """Converting preprocessed binaries into HDF5 files.
+    
+    Assume that preprocessing has already been completed using (for example) 
+    extract_trodes_rec_file.
+
+    Parameters
+    ----------
+    data_dir : str
+    animal : str
+        Name of animal
+    out_dir : str, optional (default is None)
+        Path to save preprocessed data (defaults to data_dir if None);
+        subfolders [out_dir]/[animal]/[date]/preprocessing will be created.
+    dates : list, optional (default is None)
+        Only process select dates (defaults to all available dates if None)
+    convert_spikes : bool, optional
+    convert_lfps : bool, optional
+    convert_dio : bool, optional
+    convert_mda : bool, optional
+    """
 
     importer = td.TrodesPreprocessingToAnalysis(animal_info)
 


### PR DESCRIPTION
I am trying to use the `make_HDF5` option to get out h5 files for some preliminary analysis, while I am working on the full NWB build.

But I wanted to easily do this separately _after_ the processing is done; I also wanted to only convert the LFP/spikes data but skip the dio/pos until I am ready. The optional bool arguments enable that additional control.