### PR TITLE
Bugfix: 'exportdio' string not inside of list when calling .extend

### DIFF
--- a/rec_to_binaries/trodes_data.py
+++ b/rec_to_binaries/trodes_data.py
@@ -1061,7 +1061,7 @@ class ExtractRawTrodesData:
     def extract_dio(self, dates, epochs, export_args=(), **kwargs):
         trodes_version = self.trodes_anim_info.trodes_version
         if trodes_version < 2:
-            export_cmd = 'exportdio'
+            export_cmd = ['exportdio']
         else:
             export_cmd = ['trodesexport', '-dio']
 


### PR DESCRIPTION
A variable was initialized as a string when it should have been a string inside a 1-entry list.