### PR TITLE
Restrict adjust_timestamps to selected dates

### DIFF
--- a/rec_to_binaries/core.py
+++ b/rec_to_binaries/core.py
@@ -212,8 +212,14 @@ def extract_trodes_rec_file(data_dir,
             fairly sporadic, we can recover the correspondence between trodestime
             and system (wall) time.'''
         preprocessing_dir = animal_info.get_preprocessing_dir()
-        filenames = glob.glob(os.path.join(
+        if dates is None:
+            filenames = glob.glob(os.path.join(
             preprocessing_dir, '**', '*.continuoustime.dat'), recursive=True)
+        else:
+            filenames = []
+            for date in dates:
+                filenames.extend(glob.glob(os.path.join(
+                    preprocessing_dir, date,'**', '*.continuoustime.dat')))
         for file in filenames:
             fix_timestamp_lag(file)
 


### PR DESCRIPTION
Resolves #19 

Limit preprocessing run of `adjust_timestamps_for_mcu_lag` to just the selected date(s)